### PR TITLE
fix: [#39] Hide hamburger menu on bigger screens.

### DIFF
--- a/Front-End/src/App.css
+++ b/Front-End/src/App.css
@@ -20,6 +20,11 @@ html {
   border: none;
   z-index: 1;
 }
+@media screen and (min-width: 768px) {
+  .hamburger {
+    display: none;
+  }
+}
 
 h2, .tos {
   color: white;


### PR DESCRIPTION
### **Scope of change:**
- The hamburger menu is hidden on larger screens using media query.

### **Screenshots**
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/87971509/236781745-a75c20a5-8c41-4582-bf3a-c24b4073c8be.png">

### **Notes**
This closes #39 
