### PR TITLE
Fix: [#38] Implemented menu hide on link click

### DIFF
--- a/Front-End/src/Components/Nav/Nav.jsx
+++ b/Front-End/src/Components/Nav/Nav.jsx
@@ -123,16 +123,16 @@ const Nav = () => {
           </ul>
           <hr />
           <ul>
-            <li className="bottom-links other-links">
+            <li className="bottom-links other-links" onClick={() => setShowMenu(false)}>
               <NavLink to="/howto">How to play</NavLink>
             </li>
-            <li className="bottom-links other-links">
+            <li className="bottom-links other-links" onClick={() => setShowMenu(false)}>
               <NavLink to="/tos">Terms of Services</NavLink>
             </li>
-            <li className="bottom-links other-links">
+            <li className="bottom-links other-links" onClick={() => setShowMenu(false)}>
               <NavLink to="/privacy">Privacy Policy</NavLink>
             </li>
-            <li className="bottom-links other-links">
+            <li className="bottom-links other-links" onClick={() => setShowMenu(false)}>
               <NavLink to="/bug">Report a Bug</NavLink>
             </li>
           </ul>


### PR DESCRIPTION
### Bug Fix for Issue #38 

created a click event handler for each menu item that changes the state of `setShowMenu` to false. Side bar now closes on smaller screens whenever a link is clicked.


