### PR TITLE
[FIXES #61] removed modal exit to stop users farming points and some minor text changes

### DIFF
--- a/Front-End/src/Components/Game-pages/Csgo.jsx
+++ b/Front-End/src/Components/Game-pages/Csgo.jsx
@@ -170,7 +170,6 @@ const Csgo = () => {
             {showModal && (
               <div className="modal">
                 <div className="modal-content">
-                  <span className="X" onClick={handleModal}>X</span>
                   <br />
                   <div className="modal-example">
                     <div>

--- a/Front-End/src/Components/Game-pages/League.jsx
+++ b/Front-End/src/Components/Game-pages/League.jsx
@@ -168,7 +168,6 @@ const League = () => {
             {showModal && (
               <div className="modal">
                 <div className="modal-content">
-                  <span className="X" onClick={handleModal}>X</span>
                   <br />
                   <div className="modal-example">
                     <div>

--- a/Front-End/src/Components/Game-pages/Valorant.jsx
+++ b/Front-End/src/Components/Game-pages/Valorant.jsx
@@ -171,7 +171,6 @@ return (
             {showModal && (
               <div className="modal">
                 <div className="modal-content">
-                  <span className="X" onClick={handleModal}>X</span>
                   <br />
                   <div className="modal-example">
                     <div>

--- a/Front-End/src/Components/Nav/Nav.jsx
+++ b/Front-End/src/Components/Nav/Nav.jsx
@@ -80,20 +80,20 @@ const Nav = () => {
                 to="/valorant"
                 onClick={() => setShowMenu(false)}
               />
-              <GameLink
+              {/* <GameLink
                 imgSrc={lol}
                 altText="league"
                 linkText="League"
                 to="/league"
                 onClick={() => setShowMenu(false)}
-              />
-              <GameLink
+              /> */}
+              {/* <GameLink
                 imgSrc={csgo}
                 altText="csgo"
                 linkText="CSGO"
                 to="/csgo"
                 onClick={() => setShowMenu(false)}
-              /> 
+              />  */}
               <BottomLink
                 imgSrc={submit}
                 altText="movie-logo"

--- a/Front-End/src/Components/Nav/Nav.jsx
+++ b/Front-End/src/Components/Nav/Nav.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import logo from '../../Assets/Nav-Icons/logo.png';
 import lol from '../../Assets/Nav-Icons/LoL.png';
 import val from '../../Assets/Nav-Icons/valorant.png';

--- a/Front-End/src/Components/Other-pages/Home.jsx
+++ b/Front-End/src/Components/Other-pages/Home.jsx
@@ -24,20 +24,20 @@ const Home = () => {
                   alt="valorant"
                 />
               </NavLink>
-              <NavLink to="/league">
+              {/* <NavLink to="/league">
                 <img
                   className="main-images"
                   src="https://cdn1.epicgames.com/offer/24b9b5e323bc40eea252a10cdd3b2f10/LoL_1200x1600-15ad6c981af8d98f50e833eac7843986"
                   alt="league"
                 />
-              </NavLink>
-              <NavLink to="/csgo">
+              </NavLink> */}
+              {/* <NavLink to="/csgo">
                 <img
                   className="main-images"
                   src="https://downloadwap.com/thumbs4/games/preview/2020j/img/133656_counter-st_1.jpg"
                   alt="csgo"
                 />
-              </NavLink>
+              </NavLink> */}
             </>
           ) : (
             <>

--- a/Front-End/src/Components/Other-pages/Howto.jsx
+++ b/Front-End/src/Components/Other-pages/Howto.jsx
@@ -13,13 +13,16 @@ const Howto = () => {
         <br />
         <p>Watch the clip and decide what rank the player is</p>
           <br />
-          Correct guesses are worth 1 point{' '}
+          Correct guesses are worth 2 point{' '}
           <img src={check} alt="check" width={30} />
-          <br /> Incorrect guesses will deduct 1 point{' '}
+          <br /> 
+          Guesses within 1 rank are worth 1 point{' '}
           <img src={wrong} width={40} alt="wrong icon" />
           <br />
+          <br /> 
+          Incorrect guesses will deduct 1 point{' '}
+          <img src={wrong} width={40} alt="wrong icon" />
           <br />
-          <p> Can't go under 0 points</p>
           <p>
             Get enough points to top the leaderboard{' '}
             <img src={leader} width={50} alt="board" />

--- a/Front-End/src/Components/Other-pages/Leaderboard.jsx
+++ b/Front-End/src/Components/Other-pages/Leaderboard.jsx
@@ -27,7 +27,7 @@ const Leaderboard = () => {
         {selection === 'monthly' && <Monthly />}
       </div>
       <div className="text">
-        Leaderboard refreshes every 10 minutes. Only shows top 10 players.
+        Leaderboard refreshes in real time. Only shows top 10 players.
       </div>
     </>
   );


### PR DESCRIPTION
Before: 

![c448096746bbf8bbdde76de38b38f198](https://github.com/Chris5613/RankRiddler/assets/24240227/9fc41790-edb3-4be9-af14-2666474190a5)

Has a X in the corner that can be closed and be used to farm points

After: 

![3b62f672f70135d05dae5558ca81a795](https://github.com/Chris5613/RankRiddler/assets/24240227/0a9c2f8f-d997-4d93-bcfa-5ed983f73d18)
