### PR TITLE
Responding to Issue on video being too big on mobile published by Chris5613

### DIFF
--- a/Front-End/src/App.css
+++ b/Front-End/src/App.css
@@ -178,8 +178,6 @@ h1 {
 }
 
 .video {
-  min-width: 700px;
-  min-height: 300px;
   z-index: 1;
 }
 
@@ -189,11 +187,21 @@ h1 {
 }
 
 @media screen and (max-width: 768px) {
+  .youtube-wrapper {
+    position: relative;
+    overflow: hidden;
+    justify-content: center;
+    padding-top: 56.25%;
+    margin-left: 0;
+  }
+  
   .video {
+    position: absolute;
     z-index: 1;
-    width: 70%;
+    top: 0;
+    left: 0;
+    width: 100%;
     height: 100%;
-    left: 0%;
   }
 }
 


### PR DESCRIPTION
Removed minimum size limitations in CSS and adapted wrapper to be responsive to window size below 768px.