### PR TITLE
FIX:#140 - removed setLoading from setTimeout to the end of fetchProfileData

### DIFF
--- a/Front-End/src/Components/Other-Pages/Profile.jsx
+++ b/Front-End/src/Components/Other-Pages/Profile.jsx
@@ -9,10 +9,6 @@ const Profile = () => {
   const [accuracy, setAccuracy] = useState(0);
   const { uuid } = useParams();
 
-  setTimeout(() => {
-    setLoading(false);
-  }, 1000);
-
   useEffect(() => {
     const fetchProfileData = async () => {
       try {
@@ -33,6 +29,8 @@ const Profile = () => {
         } else {
           setAccuracy(accuracy);
         }
+
+        setLoading(false);
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
earlier the loading state was hardcoded to set to false in 1 second using setTimeout, but we can never be sure in how much time our API response will come , maybe in few ms or more than 1 sec. And in more than 1 sec then the profile page will break because getting undefined in object fields.

Now it's working 
![image](https://github.com/Chris5613/RankRiddler/assets/120811481/5ac9e24f-5ece-4f43-a41e-02675aa43526)
